### PR TITLE
AB#397 Changed scheme description character limit to 10000

### DIFF
--- a/src/main/java/com/beis/subsidy/ga/schemes/dbpublishingservice/service/impl/BulkUploadSchemesServiceImpl.java
+++ b/src/main/java/com/beis/subsidy/ga/schemes/dbpublishingservice/service/impl/BulkUploadSchemesServiceImpl.java
@@ -211,11 +211,11 @@ public class BulkUploadSchemesServiceImpl implements BulkUploadSchemesService {
 
         List<BulkUploadSchemes> validateSubsidySchemeDescriptionLengthList = bulkUploadSchemes.stream()
                 .filter(scheme -> ((scheme.getSubsidySchemeDescription() != null && scheme.getSubsidySchemeDescription()
-                        .length() > 5000))).collect(Collectors.toList());
+                        .length() > 10000))).collect(Collectors.toList());
 
         validationSubsidySchemeDescriptionResultList.addAll(validateSubsidySchemeDescriptionLengthList.stream()
                 .map(scheme -> new ValidationErrorResult(String.valueOf(scheme.getRow()), columnMapping.get("Subsidy scheme description"),
-                        "The subsidy scheme description must be 5000 characters or less."))
+                        "The subsidy scheme description must be 10000 characters or less."))
                 .collect(Collectors.toList()));
 
         List<BulkUploadSchemes> validateSubsidyDescriptionNameMissingErrorList = bulkUploadSchemes.stream()

--- a/src/main/java/com/beis/subsidy/ga/schemes/dbpublishingservice/service/impl/SubsidySchemeServiceImpl.java
+++ b/src/main/java/com/beis/subsidy/ga/schemes/dbpublishingservice/service/impl/SubsidySchemeServiceImpl.java
@@ -190,6 +190,11 @@ public class SubsidySchemeServiceImpl implements SubsidySchemeService {
         schemeToSave.setLastModifiedTimestamp(LocalDate.now());
 
         if(!StringUtils.isEmpty(scheme.getSubsidySchemeDescription())) {
+            if(scheme.getSubsidySchemeDescription().length() > 10000) {
+                log.error("Subsidy scheme description must be less than 10000 characters");
+                throw new InvalidRequestException("Subsidy scheme description must be less than 10000 characters");
+            }
+
             schemeToSave.setSubsidySchemeDescription(scheme.getSubsidySchemeDescription());
         }
         if(!StringUtils.isEmpty(scheme.getSpendingSectorJson())){


### PR DESCRIPTION
Added extra validation to ensure single scheme description is <= 10000 (just in case)

Now throws invalidrequestexception when the description violates the limit